### PR TITLE
fix install guide - extraneous quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ install.packages("devtools")
 Now, install DepecheR
 ```
 library(devtools)
-install_github("Theorell/"DepecheR", ref = "Rversion3.5")
+install_github("Theorell/DepecheR", ref = "Rversion3.5")
 ```


### PR DESCRIPTION
The quote prevents the package from installing correctly :) 

By the way, I think this might be present in the master branch readme, too. 

