### PR TITLE
bug fix: src/Makevars incorrect test

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -3,6 +3,6 @@ PKG_CPPFLAGS = -I../inst/include -pthread
 
 # strip debug symbols for smaller Linux binaries
 strippedLib: $(SHLIB)
-		if test -e "/usr/bin/strip" & test -e "/bin/uname" & [[ `uname` == "Linux" ]] ; then /usr/bin/strip --strip-debug $(SHLIB); fi
+		if test -e "/usr/bin/strip" && test -e "/bin/uname" && [[ `uname` == "Linux" ]] ; then /usr/bin/strip --strip-debug $(SHLIB); fi
 		rm *.o
 .phony: strippedLib


### PR DESCRIPTION
Dear,

The logical *and* (`&`) seems incorrect.

Best regards,
simon

